### PR TITLE
Atualização do README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,66 +1,33 @@
-# Book Starter
+# Eliminando o risco
 
-A starter built with gatsby to help you create books with ease.
+Tradução do livro "De-risking Government Technology" (inserir fonte). (objectivos)
 
-- 📖 Create Book from markdown files
-- 🖼 Generate PDF with Light and Dark Mode
-- 📚 Generates Epub file
-- 👩‍💻 Creates a preview site
+# Como colaborar
 
-[PDF Light Example](./book/book-light.pdf)
+## Como usar
 
-[PDF Dark Example](./book/book-dark.pdf)
-
-[Epub Example](./book/book.epub)
-
-[Website Example](https://wizardly-snyder-c98440.netlify.com/) (add `?theme=dark` to preview dark version)
-
-## How to use
-
-1. First git clone and cd into the folder
+1. Primeiro fazer `git clone`
 
 ```bash
-git clone git@github.com:SaraVieira/starter-book.git my-book && cd my-book
+git clone git@github.com:administracaopublicadigital/eliminando-o-risco.git eliminando-o-risco && cd eliminando-o-risco
 ```
 
-2. Edit your book in the `book.md`
-3. Set you book properties in `bookInfo.js`
-4. Run `yarn build`
+2. Editar o livro no ficheiro `book.md`
+3. Definir as propriedades do livro em `bookInfo.js`
+4. Correr o comando `yarn build`
 
-   4.1. You can also run `yarn build:site` to build just the preview site
+   4.1. Também é possível executar o comando `yarn build:site` para visualizar um preview do site
 
-   4.2. Or run `yarn build:book` for the PDF and Epub files
+   4.2. Ou executar `yarn build:book` para os ficheiros PDF e Epub
 
-5. To get the .mobi file download the [Kindle Previewer](https://kdp.amazon.com/en_US/help/topic/G202131170) and drag your .epub file and it creates a kindle compatible file.
-6. Profit??
+5. Para o ficheiro .mobi, fazer download do [Kindle Previewer](https://kdp.amazon.com/en_US/help/topic/G202131170) e arrastar o ficheiro .epub gerado no ponto 4.2 para criar um ficheiro compatível com Kindle.
 
-## FAQ
+## Como submeter alterações
 
-### How can I edit the CSS?
+1. Criar um *fork* do repositório original;
+2. Realizar as alterações pretendidas num novo branch;
+3. Criar um Pull Request com uma breve explicação das alterações.
 
-The CSS is located in [./src/styles/style.scss](./src/styles/style.scss) and you can edit it there. At the bottom you will see all the styles specific for the dark version.
+# Créditos
 
-### How can I change the Prism theme?
-
-I import the prism theme in [./src/pages/index.js](./src/pages/index.js) and in there you can use any theme or make your own and use it by importing. I made a tool you can see [here](http://prism.dotenv.dev/) that helps you make your VSCode theme into a prism theme easily.
-
-### The chapters are screwed up in my version
-
-I use a really HUUUUGE hack to get them, I go through every H1 created by the markdown file and make that into a chapter so I can only recognize H1's as chapters at least until I find a better way :(
-If you want to try and fix that the code is at [./generate-book/epub.js](./generate-book/epub.js).
-
-## Why?
-
-I built this in order to be able to publish a book I wrote and I think it may be useful for someone so I made it open source.
-
-## Books using this:
-
-- [Opinionated Guide to React](http://opinionatedreact.com/)
-
-Let me know if you are using this to make your book :)
-
----
-
-Any issues please make a PR or file a bug
-
-Licensed under the MIT license
+Base do projecto criado a partir do [starter-book](https://github.com/SaraVieira/starter-book) da Sara Vieira.


### PR DESCRIPTION
- Placeholders para descrição mais detalhada do objetivo do livro (@pgte). Acredito que seja mais fácil para uma nova pessoa perceber o que se passa neste repositório (e mais facilmente ajudar) se o README explicar bem as motivações por trás do projecto.
- Traduzido para português. 
- git clone aponta para o administracaopublicadigital/eliminando-o-risco em vez do bootstrap da Sara Vieira (kudos no final do README)